### PR TITLE
Add pi support

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ $ python -m reproducible_trajectories verify-trajectories . --json
 
 ### open-source-trajectories
 
-`open-source-trajectories` is the easiest way to contribute your local Claude Code and OpenAI Codex CLI trajectories to science. It scans `~/.claude/projects/` (Claude Code) and `~/.codex/sessions/` (OpenAI Codex CLI), identifies trajectories whose edits are confined to a single public GitHub repository, and offers to upload them to the KTH research dataset.
+`open-source-trajectories` is the easiest way to contribute your local Claude Code, pi coding agent, and OpenAI Codex CLI trajectories to science. It scans `~/.claude/projects/` (Claude Code), `~/.pi/agent/sessions/` (pi coding agent), and `~/.codex/sessions/` (OpenAI Codex CLI), identifies trajectories whose edits are confined to a single public GitHub repository, and offers to upload them to the KTH research dataset.
 
 **Why it matters for science**: Trajectories produced on open-source projects are themselves open data — the code they touch is public, the repository is public, and the agent's reasoning process is therefore safe to share. Collecting these trajectories at scale enables empirical studies that are otherwise impossible: How do AI agents navigate real codebases? Which tool-use patterns lead to correct, mergeable commits? How does agent behaviour vary across programming languages or project sizes? Every trajectory you share is a data point that helps answer these questions.
 
@@ -190,7 +190,7 @@ python -m reproducible_trajectories open-source-trajectories
 ```
 
 The command will:
-1. Scan all local trajectories (both Claude Code and Codex CLI) and filter those that only edit files inside a single public GitHub repository.
+1. Scan all local trajectories (Claude Code, pi coding agent, and Codex CLI) and filter those that only edit files inside a single public GitHub repository.
 2. Display the list of repos and edited files found.
 3. Ask whether you agree to share all of them, or step through them repo by repo.
 4. Zip and upload the approved trajectories together with a `metadata.json` containing your git email and the GitHub repo URLs.
@@ -218,6 +218,7 @@ python -m reproducible_trajectories open-source-trajectories --yes
 **Custom agent directories**:
 
 ```sh
+PI_CODING_AGENT_DIR=/path/to/.pi/agent \
 python -m reproducible_trajectories open-source-trajectories \
   --claude-dir /path/to/.claude \
   --codex-dir /path/to/.codex
@@ -225,6 +226,7 @@ python -m reproducible_trajectories open-source-trajectories \
 
 Supported agent trace formats:
 - **Claude Code** (`~/.claude/projects/**/*.jsonl`) — uses `Write`, `Edit`, `NotebookEdit` tool calls
+- **pi coding agent** (`~/.pi/agent/sessions/**/*.jsonl`, or `$PI_CODING_AGENT_DIR/sessions/**/*.jsonl`) — normalized to Claude-style `Read`/`Write`/`Edit`/`Bash` tool calls
 - **OpenAI Codex CLI** (`~/.codex/sessions/**/*.jsonl`) — uses `write_file` and `apply_patch` tool calls (both OpenAI custom patch format and standard unified diff)
 
 ### collect-trajectories

--- a/reproducible_trajectories/pi_trajectory.py
+++ b/reproducible_trajectories/pi_trajectory.py
@@ -1,0 +1,118 @@
+"""
+Pi coding agent trajectory support.
+
+Detects and normalizes pi trajectories into the Claude Code format
+used by the rest of the codebase.
+"""
+
+import os
+from pathlib import Path
+
+
+def is_pi_trajectory(events):
+    """Detect pi coding agent trajectory format."""
+    for e in events:
+        if e.get("type") == "session" and "cwd" in e:
+            return True
+        if e.get("type") == "message" and e.get("message", {}).get("role") == "toolResult":
+            return True
+        if e.get("type") == "message":
+            for c in e.get("message", {}).get("content", []):
+                if isinstance(c, dict) and c.get("type") == "toolCall":
+                    return True
+    return False
+
+
+# Map pi tool names/args to Claude Code equivalents.
+_TOOL_NAMES = {"read": "Read", "write": "Write", "edit": "Edit", "bash": "Bash"}
+_ARG_MAP = {
+    "read":  {"path": "file_path"},
+    "write": {"path": "file_path", "content": "content"},
+    "edit":  {"path": "file_path", "oldText": "old_string", "newText": "new_string",
+              "replace_all": "replace_all"},
+}
+
+
+def _normalize_tool_call(item):
+    """Convert a pi toolCall content item to Claude Code tool_use format."""
+    name = item.get("name", "")
+    cc_name = _TOOL_NAMES.get(name, name.capitalize())
+    args = item.get("arguments", {})
+    arg_map = _ARG_MAP.get(name, {})
+    cc_input = {}
+    for pi_key, val in args.items():
+        cc_key = arg_map.get(pi_key, pi_key)
+        cc_input[cc_key] = val
+    return {
+        "type": "tool_use",
+        "id": item.get("id", ""),
+        "name": cc_name,
+        "input": cc_input,
+    }
+
+
+def normalize_trajectory(events):
+    """Convert pi trajectory events to Claude Code format."""
+    normalized = []
+
+    # Extract session info and emit it as a Claude-style event.
+    session_id = None
+    cwd = None
+    for e in events:
+        if e.get("type") == "session":
+            session_id = e.get("id")
+            cwd = e.get("cwd")
+            break
+
+    if session_id or cwd:
+        normalized.append({"sessionId": session_id, "cwd": cwd})
+
+    for e in events:
+        if e.get("type") != "message":
+            continue
+        msg = e.get("message", {})
+        role = msg.get("role")
+
+        if role == "assistant":
+            new_content = []
+            for c in msg.get("content", []):
+                if isinstance(c, dict) and c.get("type") == "toolCall":
+                    new_content.append(_normalize_tool_call(c))
+                elif isinstance(c, dict) and c.get("type") == "thinking":
+                    continue
+                else:
+                    new_content.append(c)
+            normalized.append({"message": {"role": "assistant", "content": new_content}})
+
+        elif role == "toolResult":
+            tool_call_id = msg.get("toolCallId", "")
+            content = msg.get("content", "")
+            normalized.append({
+                "message": {
+                    "role": "user",
+                    "content": [{
+                        "type": "tool_result",
+                        "tool_use_id": tool_call_id,
+                        "content": content,
+                    }],
+                }
+            })
+
+        elif role == "user":
+            normalized.append({"message": msg})
+
+    return normalized
+
+
+def resolve_session_path(trajectory_arg):
+    """Search pi session directories for a trajectory by ID fragment."""
+    pi_agent_dir = os.environ.get("PI_CODING_AGENT_DIR")
+    if pi_agent_dir:
+        pi_sessions = Path(pi_agent_dir) / "sessions"
+    else:
+        pi_sessions = Path.home() / ".pi" / "agent" / "sessions"
+    if pi_sessions.is_dir():
+        matches = [p for p in pi_sessions.rglob("*.jsonl") if trajectory_arg in p.name]
+        if matches:
+            return str(matches[0])
+    return None

--- a/reproducible_trajectories/pi_trajectory.py
+++ b/reproducible_trajectories/pi_trajectory.py
@@ -9,6 +9,21 @@ import os
 from pathlib import Path
 
 
+def get_sessions_dir():
+    """Return the pi sessions directory."""
+    pi_agent_dir = os.environ.get("PI_CODING_AGENT_DIR")
+    if pi_agent_dir:
+        return Path(pi_agent_dir) / "sessions"
+    return Path.home() / ".pi" / "agent" / "sessions"
+
+
+def iter_session_paths():
+    """Yield all pi session JSONL files."""
+    pi_sessions = get_sessions_dir()
+    if pi_sessions.is_dir():
+        yield from sorted(pi_sessions.rglob("*.jsonl"))
+
+
 def is_pi_trajectory(events):
     """Detect pi coding agent trajectory format."""
     for e in events:
@@ -106,13 +121,7 @@ def normalize_trajectory(events):
 
 def resolve_session_path(trajectory_arg):
     """Search pi session directories for a trajectory by ID fragment."""
-    pi_agent_dir = os.environ.get("PI_CODING_AGENT_DIR")
-    if pi_agent_dir:
-        pi_sessions = Path(pi_agent_dir) / "sessions"
-    else:
-        pi_sessions = Path.home() / ".pi" / "agent" / "sessions"
-    if pi_sessions.is_dir():
-        matches = [p for p in pi_sessions.rglob("*.jsonl") if trajectory_arg in p.name]
-        if matches:
-            return str(matches[0])
+    matches = [p for p in iter_session_paths() if trajectory_arg in p.name]
+    if matches:
+        return str(matches[0])
     return None

--- a/reproducible_trajectories/trajectory.py
+++ b/reproducible_trajectories/trajectory.py
@@ -18,7 +18,10 @@ import sys
 from collections import defaultdict
 from pathlib import Path
 
-import pi_trajectory
+try:
+    from . import pi_trajectory
+except ImportError:  # pragma: no cover - allows direct script execution
+    import pi_trajectory
 
 
 # ---------------------------------------------------------------------------

--- a/reproducible_trajectories/trajectory.py
+++ b/reproducible_trajectories/trajectory.py
@@ -18,6 +18,8 @@ import sys
 from collections import defaultdict
 from pathlib import Path
 
+import pi_trajectory
+
 
 # ---------------------------------------------------------------------------
 # Shared helpers
@@ -30,6 +32,8 @@ def parse_trajectory(path):
             line = line.strip()
             if line:
                 events.append(json.loads(line))
+    if pi_trajectory.is_pi_trajectory(events):
+        events = pi_trajectory.normalize_trajectory(events)
     return events
 
 
@@ -67,6 +71,9 @@ def resolve_trajectory_path(trajectory_arg, claude_dir):
     matches = list(Path(claude_dir).glob(f"projects/**/{trajectory_arg}.jsonl"))
     if matches:
         return str(matches[0])
+    pi_match = pi_trajectory.resolve_session_path(trajectory_arg)
+    if pi_match:
+        return pi_match
     return trajectory_arg
 
 

--- a/reproducible_trajectories/trajectory.py
+++ b/reproducible_trajectories/trajectory.py
@@ -971,8 +971,7 @@ def _collect_codex_modifications(events, session_cwd=None):
 
 def open_source_trajectories(claude_dir=None, codex_dir=None):
     """
-    Scan all trajectories in ~/.claude/projects/ and ~/.codex/sessions/ and
-    return those where:
+    Scan Claude Code, pi, and Codex trajectories and return those where:
       1. Every edit is within a single git repository.
       2. That git repository has at least one public GitHub remote.
 
@@ -1035,6 +1034,16 @@ def open_source_trajectories(claude_dir=None, codex_dir=None):
 
     # --- Claude Code trajectories ---
     for traj_path in sorted(claude_dir.glob('projects/**/*.jsonl')):
+        try:
+            events = parse_trajectory(str(traj_path))
+        except (json.JSONDecodeError, OSError):
+            continue
+        sequence, _tool_uses = build_sequence(events)
+        modifications = collect_modifications(sequence)
+        _process_modifications(traj_path, modifications)
+
+    # --- pi trajectories ---
+    for traj_path in pi_trajectory.iter_session_paths():
         try:
             events = parse_trajectory(str(traj_path))
         except (json.JSONDecodeError, OSError):
@@ -1166,7 +1175,7 @@ def main(argv=None):
 
     p_oss = subparsers.add_parser(
         "open-source-trajectories",
-        help="List trajectories whose edits are all within a public GitHub repo",
+        help="List Claude/pi/Codex trajectories whose edits are all within a public GitHub repo",
     )
     p_oss.add_argument(
         "--claude-dir",

--- a/tests/test_pi_trajectory.py
+++ b/tests/test_pi_trajectory.py
@@ -1,4 +1,5 @@
 import json
+import subprocess
 from pathlib import Path
 
 
@@ -192,3 +193,64 @@ class TestResolvePiSessionPath:
 
         resolved = resolve_trajectory_path("pi-session-456", str(tmp_path / "claude"))
         assert resolved == str(traj)
+
+
+class TestOpenSourceTrajectoriesWithPi:
+    def test_scans_pi_sessions(self, tmp_path, monkeypatch):
+        from reproducible_trajectories.trajectory import open_source_trajectories
+
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        subprocess.run(["git", "init", str(repo)], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "remote", "add", "origin", "https://github.com/example/public-repo.git"],
+            check=True,
+            capture_output=True,
+            cwd=str(repo),
+        )
+
+        pi_dir = tmp_path / ".pi-agent"
+        sessions = pi_dir / "sessions" / "project"
+        sessions.mkdir(parents=True)
+        traj = sessions / "pi-open-source.jsonl"
+        _write_jsonl(
+            traj,
+            [
+                {"type": "session", "id": "sess-1", "cwd": str(repo)},
+                {
+                    "type": "message",
+                    "message": {
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "toolCall",
+                                "id": "call-1",
+                                "name": "write",
+                                "arguments": {
+                                    "path": str(repo / "f.py"),
+                                    "content": "x = 1\n",
+                                },
+                            }
+                        ],
+                    },
+                },
+                {
+                    "type": "message",
+                    "message": {"role": "toolResult", "toolCallId": "call-1", "content": "OK"},
+                },
+            ],
+        )
+
+        monkeypatch.setenv("PI_CODING_AGENT_DIR", str(pi_dir))
+        monkeypatch.setattr(
+            "reproducible_trajectories.trajectory._is_public_github_repo",
+            lambda owner_repo: True,
+        )
+
+        results = open_source_trajectories(claude_dir=str(tmp_path / "claude"), codex_dir=str(tmp_path / "codex"))
+
+        assert len(results) == 1
+        assert results[0]["local_folder"] == str(repo)
+        assert results[0]["github_repo"] == "https://github.com/example/public-repo"
+        assert results[0]["trajectories"] == [str(traj)]
+        assert results[0]["edited_files"] == [str(repo / "f.py")]

--- a/tests/test_pi_trajectory.py
+++ b/tests/test_pi_trajectory.py
@@ -1,0 +1,194 @@
+import json
+from pathlib import Path
+
+
+def _write_jsonl(path, events):
+    with open(path, "w") as f:
+        for e in events:
+            f.write(json.dumps(e) + "\n")
+
+
+class TestIsPiTrajectory:
+    def test_detects_session_event(self):
+        from reproducible_trajectories.pi_trajectory import is_pi_trajectory
+
+        events = [{"type": "session", "id": "sess-1", "cwd": "/repo"}]
+        assert is_pi_trajectory(events) is True
+
+    def test_detects_tool_call_event(self):
+        from reproducible_trajectories.pi_trajectory import is_pi_trajectory
+
+        events = [
+            {
+                "type": "message",
+                "message": {
+                    "role": "assistant",
+                    "content": [{"type": "toolCall", "id": "tc1", "name": "read", "arguments": {"path": "a.py"}}],
+                },
+            }
+        ]
+        assert is_pi_trajectory(events) is True
+
+    def test_returns_false_for_non_pi_events(self):
+        from reproducible_trajectories.pi_trajectory import is_pi_trajectory
+
+        events = [
+            {
+                "type": "assistant",
+                "message": {
+                    "role": "assistant",
+                    "content": [{"type": "tool_use", "id": "t1", "name": "Read", "input": {"file_path": "/repo/a.py"}}],
+                },
+            }
+        ]
+        assert is_pi_trajectory(events) is False
+
+
+class TestNormalizeTrajectory:
+    def test_normalizes_pi_events_to_claude_format(self):
+        from reproducible_trajectories.pi_trajectory import normalize_trajectory
+
+        events = [
+            {"type": "session", "id": "sess-1", "cwd": "/repo"},
+            {
+                "type": "message",
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "thinking", "text": "skip me"},
+                        {"type": "text", "text": "I will read the file."},
+                        {"type": "toolCall", "id": "call-1", "name": "read", "arguments": {"path": "/repo/a.py"}},
+                        {
+                            "type": "toolCall",
+                            "id": "call-2",
+                            "name": "edit",
+                            "arguments": {
+                                "path": "/repo/a.py",
+                                "oldText": "old",
+                                "newText": "new",
+                                "replace_all": True,
+                            },
+                        },
+                    ],
+                },
+            },
+            {
+                "type": "message",
+                "message": {
+                    "role": "toolResult",
+                    "toolCallId": "call-1",
+                    "content": [{"type": "text", "text": "file contents"}],
+                },
+            },
+            {
+                "type": "message",
+                "message": {
+                    "role": "user",
+                    "content": "please continue",
+                },
+            },
+        ]
+
+        normalized = normalize_trajectory(events)
+
+        assert normalized[0] == {"sessionId": "sess-1", "cwd": "/repo"}
+        assert normalized[1]["message"]["role"] == "assistant"
+        assert normalized[1]["message"]["content"][0] == {"type": "text", "text": "I will read the file."}
+        assert normalized[1]["message"]["content"][1] == {
+            "type": "tool_use",
+            "id": "call-1",
+            "name": "Read",
+            "input": {"file_path": "/repo/a.py"},
+        }
+        assert normalized[1]["message"]["content"][2] == {
+            "type": "tool_use",
+            "id": "call-2",
+            "name": "Edit",
+            "input": {
+                "file_path": "/repo/a.py",
+                "old_string": "old",
+                "new_string": "new",
+                "replace_all": True,
+            },
+        }
+        assert normalized[2] == {
+            "message": {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "call-1",
+                        "content": [{"type": "text", "text": "file contents"}],
+                    }
+                ],
+            }
+        }
+        assert normalized[3] == {
+            "message": {"role": "user", "content": "please continue"}
+        }
+
+    def test_parse_trajectory_normalizes_pi_file(self, tmp_path):
+        from reproducible_trajectories.trajectory import parse_trajectory
+
+        traj = tmp_path / "pi-session.jsonl"
+        events = [
+            {"type": "session", "id": "sess-1", "cwd": "/repo"},
+            {
+                "type": "message",
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "toolCall", "id": "call-1", "name": "write", "arguments": {"path": "/repo/out.py", "content": "x = 1\n"}}
+                    ],
+                },
+            },
+            {
+                "type": "message",
+                "message": {"role": "toolResult", "toolCallId": "call-1", "content": "OK"},
+            },
+        ]
+        _write_jsonl(traj, events)
+
+        parsed = parse_trajectory(str(traj))
+
+        assert parsed[0] == {"sessionId": "sess-1", "cwd": "/repo"}
+        assert parsed[1]["message"]["content"][0] == {
+            "type": "tool_use",
+            "id": "call-1",
+            "name": "Write",
+            "input": {"file_path": "/repo/out.py", "content": "x = 1\n"},
+        }
+        assert parsed[2]["message"]["content"][0] == {
+            "type": "tool_result",
+            "tool_use_id": "call-1",
+            "content": "OK",
+        }
+
+
+class TestResolvePiSessionPath:
+    def test_resolves_from_pi_coding_agent_dir(self, tmp_path, monkeypatch):
+        from reproducible_trajectories.pi_trajectory import resolve_session_path
+
+        pi_dir = tmp_path / ".pi-agent"
+        sessions = pi_dir / "sessions" / "project"
+        sessions.mkdir(parents=True)
+        traj = sessions / "abc123-session.jsonl"
+        traj.write_text("{}\n")
+
+        monkeypatch.setenv("PI_CODING_AGENT_DIR", str(pi_dir))
+
+        assert resolve_session_path("abc123") == str(traj)
+
+    def test_resolve_trajectory_path_uses_pi_session_lookup(self, tmp_path, monkeypatch):
+        from reproducible_trajectories.trajectory import resolve_trajectory_path
+
+        pi_dir = tmp_path / ".pi-agent"
+        sessions = pi_dir / "sessions" / "project"
+        sessions.mkdir(parents=True)
+        traj = sessions / "pi-session-456.jsonl"
+        traj.write_text("{}\n")
+
+        monkeypatch.setenv("PI_CODING_AGENT_DIR", str(pi_dir))
+
+        resolved = resolve_trajectory_path("pi-session-456", str(tmp_path / "claude"))
+        assert resolved == str(traj)


### PR DESCRIPTION
I think this support is a bit more thorough than what was fixed for Codex in the other PR. Pi is the agent harness I almost always use.

You should have received a pi trajectory to the api submitted with `uv run python -m reproducible-trajectories open-source-trajectories`. A (only partial sorry) trajectory for the implementation of this PR.

The implementation works by normalizing Pi sessions to claude format, and then reusing the existing logic from there on.

You might notice that custom agent directories are not configured with a flag, but with an env var, which looks inconsistent. The reason for this is that Pi itself follows this env var by default, and now `reproducible-trajectories` has been configured to simply pick up on the same source of truth that Pi itself will follow.