### PR TITLE
Rename sharing command and add all-trajectories option

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,9 +176,9 @@ $ python -m reproducible_trajectories verify-trajectories . --json
 ]
 ```
 
-### open-source-trajectories
+### share-trajectories
 
-`open-source-trajectories` is the easiest way to contribute your local Claude Code, pi coding agent, and OpenAI Codex CLI trajectories to science. It scans `~/.claude/projects/` (Claude Code), `~/.pi/agent/sessions/` (pi coding agent), and `~/.codex/sessions/` (OpenAI Codex CLI), identifies trajectories whose edits are confined to a single public GitHub repository, and offers to upload them to the KTH research dataset.
+`share-trajectories` is the easiest way to contribute your local Claude Code, pi coding agent, and OpenAI Codex CLI trajectories to science. It scans `~/.claude/projects/` (Claude Code), `~/.pi/agent/sessions/` (pi coding agent), and `~/.codex/sessions/` (OpenAI Codex CLI), then lets you choose whether to share all trajectories or only the ones from open-source repositories.
 
 **Why it matters for science**: Trajectories produced on open-source projects are themselves open data — the code they touch is public, the repository is public, and the agent's reasoning process is therefore safe to share. Collecting these trajectories at scale enables empirical studies that are otherwise impossible: How do AI agents navigate real codebases? Which tool-use patterns lead to correct, mergeable commits? How does agent behaviour vary across programming languages or project sizes? Every trajectory you share is a data point that helps answer these questions.
 
@@ -186,19 +186,26 @@ $ python -m reproducible_trajectories verify-trajectories . --json
 
 ```sh
 pip install reproducible-trajectories
-python -m reproducible_trajectories open-source-trajectories
+python -m reproducible_trajectories share-trajectories
 ```
 
 The command will:
-1. Scan all local trajectories (Claude Code, pi coding agent, and Codex CLI) and filter those that only edit files inside a single public GitHub repository.
-2. Display the list of repos and edited files found.
-3. Ask whether you agree to share all of them, or step through them repo by repo.
-4. Zip and upload the approved trajectories together with a `metadata.json` containing your git email and the GitHub repo URLs.
-5. Ask whether to install a `pre-commit` hook in each repo so future trajectories are shared automatically.
-6. Print a summary: trajectories uploaded, hooks added.
+1. Start by asking whether you want to share all trajectories or only the ones from open-source repositories.
+2. Reassure you that all collected data will be properly filtered and anonymized.
+3. Scan all local trajectories (Claude Code, pi coding agent, and Codex CLI) and keep those whose edits stay within a single git repository.
+4. Display the repos and edited files found for the selected scope.
+5. Ask whether you agree to share all of them, or step through them repo by repo.
+6. Zip and upload the approved trajectories together with a `metadata.json` containing your git email and any public GitHub repo URLs that were found.
+7. Ask whether to install a `pre-commit` hook in each repo so future trajectories are shared automatically.
+8. Print a summary: trajectories uploaded, hooks added.
 
 ```
-$ python -m reproducible_trajectories open-source-trajectories
+$ python -m reproducible_trajectories share-trajectories
+Do you want to:
+  1) share all trajectories
+  2) only share the ones from open-source repositories
+All collected data will be properly filtered and anonymized. [1/2/N] 2
+
 🔍 Found 20 trajectories in open-source repos
 
 /home/user/myproject  https://github.com/org/myproject
@@ -212,8 +219,11 @@ Do you agree to share them all with the KTH experiment on coding agents? [y/N]
 **Non-interactive mode** (for use in scripts or hooks):
 
 ```sh
-python -m reproducible_trajectories open-source-trajectories --yes
+python -m reproducible_trajectories share-trajectories --scope open-source --yes
+python -m reproducible_trajectories share-trajectories --scope all --yes
 ```
+
+`open-source-trajectories` remains available as a backward-compatible alias.
 
 **Custom agent directories**:
 

--- a/reproducible_trajectories/trajectory.py
+++ b/reproducible_trajectories/trajectory.py
@@ -885,6 +885,20 @@ def _is_public_github_repo(owner_repo):
         return False
 
 
+def _public_github_repo_url(repo_root, public_cache):
+    """Return a public GitHub repo URL for repo_root, or None."""
+    github_urls = _get_github_remote_urls(repo_root)
+    for url in sorted(github_urls):
+        owner_repo = _parse_github_owner_repo(url)
+        if owner_repo is None:
+            continue
+        if owner_repo not in public_cache:
+            public_cache[owner_repo] = _is_public_github_repo(owner_repo)
+        if public_cache[owner_repo]:
+            return f'https://github.com/{owner_repo}'
+    return None
+
+
 def _get_codex_session_info(events):
     """
     Extract (session_id, cwd) from OpenAI Codex CLI session events.
@@ -1014,14 +1028,15 @@ def _collect_codex_modifications(events, session_cwd=None):
     return seen
 
 
-def open_source_trajectories(claude_dir=None, codex_dir=None):
+def collect_shareable_trajectories(claude_dir=None, codex_dir=None, public_only=False):
     """
-    Scan Claude Code, pi, and Codex trajectories and return those where:
-      1. Every edit is within a single git repository.
-      2. That git repository has at least one public GitHub remote.
+    Scan Claude Code, pi, and Codex trajectories and return those where every
+    edit is within a single git repository.
 
     Returns list of dicts, one per unique (local_folder, github_repo) pair:
       {local_folder, github_repo, trajectories: [...], edited_files: [...]}
+
+    If public_only is True, only keep repositories with a public GitHub remote.
     """
     if claude_dir is None:
         claude_dir = Path.home() / '.claude'
@@ -1036,7 +1051,7 @@ def open_source_trajectories(claude_dir=None, codex_dir=None):
     _public_cache = {}
 
     def _process_modifications(traj_path, modifications):
-        """Shared logic: group trajectory by public-GitHub repo."""
+        """Shared logic: group a trajectory by git repo and public GitHub URL."""
         if not modifications:
             return
 
@@ -1055,20 +1070,8 @@ def open_source_trajectories(claude_dir=None, codex_dir=None):
 
         repo_root = next(iter(git_roots))
 
-        # Find a public GitHub remote for this repo
-        github_urls = _get_github_remote_urls(repo_root)
-        public_repo_url = None
-        for url in sorted(github_urls):
-            owner_repo = _parse_github_owner_repo(url)
-            if owner_repo is None:
-                continue
-            if owner_repo not in _public_cache:
-                _public_cache[owner_repo] = _is_public_github_repo(owner_repo)
-            if _public_cache[owner_repo]:
-                public_repo_url = f'https://github.com/{owner_repo}'
-                break
-
-        if public_repo_url is None:
+        public_repo_url = _public_github_repo_url(repo_root, _public_cache)
+        if public_only and public_repo_url is None:
             return
 
         key = (repo_root, public_repo_url)
@@ -1121,6 +1124,60 @@ def open_source_trajectories(claude_dir=None, codex_dir=None):
         }
         for (local_folder, github_repo), info in sorted(groups.items())
     ]
+
+
+def open_source_trajectories(claude_dir=None, codex_dir=None):
+    """Return shareable trajectories limited to public GitHub repositories."""
+    return collect_shareable_trajectories(
+        claude_dir=claude_dir,
+        codex_dir=codex_dir,
+        public_only=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# share-trajectories CLI helpers
+# ---------------------------------------------------------------------------
+
+def _prompt_share_scope():
+    """Ask whether to share all trajectories or only open-source ones."""
+    print("Do you want to:")
+    print("  1) share all trajectories")
+    print("  2) only share the ones from open-source repositories")
+    answer = input(
+        "All collected data will be properly filtered and anonymized. [1/2/N] "
+    ).strip().lower()
+    if answer == '1':
+        return 'all'
+    if answer == '2':
+        return 'open-source'
+    return None
+
+
+def _share_scope_results(all_results, scope):
+    """Return the repository groups matching the selected sharing scope."""
+    if scope == 'all':
+        return all_results
+    return [r for r in all_results if r['github_repo']]
+
+
+def _share_scope_label(scope):
+    """Return a human-readable label for the selected sharing scope."""
+    if scope == 'all':
+        return 'all repos'
+    return 'open-source repos'
+
+
+def _share_target_label(result):
+    """Return the best label for a share target."""
+    return result['github_repo'] or f"{result['local_folder']}  (private/non-GitHub repo)"
+
+
+def _share_target_slug(result, index):
+    """Return a stable archive folder name for a share target."""
+    if result['github_repo']:
+        return result['github_repo'].replace('https://github.com/', '').replace('/', '_')
+    return f"repo_{index:03d}"
 
 
 # ---------------------------------------------------------------------------
@@ -1218,18 +1275,29 @@ def main(argv=None):
         help="Report what would be copied without writing anything",
     )
 
-    p_oss = subparsers.add_parser(
-        "open-source-trajectories",
-        help="List Claude/pi/Codex trajectories whose edits are all within a public GitHub repo",
+    p_share = subparsers.add_parser(
+        "share-trajectories",
+        aliases=["open-source-trajectories"],
+        help="Share local trajectories from all repos or only open-source ones",
     )
-    p_oss.add_argument(
+    p_share.add_argument(
         "--claude-dir",
         default=None,
         help="Path to .claude directory (default: ~/.claude)",
     )
-    p_oss.add_argument("--json", action="store_true", help="Output results as JSON")
-    p_oss.add_argument("--yes", action="store_true", help="Auto-confirm sharing all repos (non-interactive)")
-    p_oss.add_argument(
+    p_share.add_argument("--json", action="store_true", help="Output results as JSON")
+    p_share.add_argument(
+        "--yes",
+        action="store_true",
+        help="Auto-confirm sharing all trajectories for the selected scope",
+    )
+    p_share.add_argument(
+        "--scope",
+        choices=["all", "open-source"],
+        default=None,
+        help="Sharing scope for non-interactive use (default: ask interactively)",
+    )
+    p_share.add_argument(
         "--codex-dir",
         default=None,
         help="Path to Codex CLI sessions directory (default: ~/.codex)",
@@ -1274,19 +1342,33 @@ def main(argv=None):
         collect_run()
         return
 
-    if args.command == "open-source-trajectories":
+    if args.command in ("share-trajectories", "open-source-trajectories"):
         codex_dir = args.codex_dir if hasattr(args, 'codex_dir') else None
-        results = open_source_trajectories(claude_dir=str(claude_dir), codex_dir=codex_dir)
+        all_results = collect_shareable_trajectories(
+            claude_dir=str(claude_dir),
+            codex_dir=codex_dir,
+        )
+        selected_scope = args.scope
+        if selected_scope is None:
+            if args.command == "open-source-trajectories" or args.yes or args.json:
+                selected_scope = "open-source"
+            else:
+                selected_scope = _prompt_share_scope()
+                if selected_scope is None:
+                    print("Sharing cancelled.")
+                    return
+        results = _share_scope_results(all_results, selected_scope)
         if args.json:
             print(json.dumps(results, indent=2))
             return
         n = sum(len(r['trajectories']) for r in results)
-        print(f"🔍 Found {n} trajectories in open-source repos")
+        print(f"🔍 Found {n} trajectories in {_share_scope_label(selected_scope)}")
         if not results:
+            print("No trajectories available for the selected scope.")
             return
         print()
         for r in results:
-            print(f"{r['local_folder']}  {r['github_repo']}")
+            print(f"{r['local_folder']}  {_share_target_label(r)}")
             for f in r['edited_files']:
                 print(f"  {f}")
         print()
@@ -1297,13 +1379,17 @@ def main(argv=None):
         if args.yes:
             answer = 'y'
         else:
-            answer = input("Do you agree to share them all with the KTH experiment on coding agents? [y/N] ").strip().lower()
+            answer = input(
+                "Do you agree to share all of these trajectories with the KTH experiment on coding agents? [y/N] "
+            ).strip().lower()
         if answer == 'y':
             approved = results
         else:
             approved = []
             for r in results:
-                a = input(f"  Share {r['github_repo']} ({len(r['trajectories'])} trajectories)? [y/N] ").strip().lower()
+                a = input(
+                    f"  Share {_share_target_label(r)} ({len(r['trajectories'])} trajectories)? [y/N] "
+                ).strip().lower()
                 if a == 'y':
                     approved.append(r)
 
@@ -1315,6 +1401,7 @@ def main(argv=None):
         github_urls = sorted({r['github_repo'] for r in approved})
         metadata = {
             'git_email': git_email,
+            'share_scope': selected_scope,
             'github_repos': github_urls,
             'trajectories': all_trajs,
         }
@@ -1322,8 +1409,8 @@ def main(argv=None):
             zip_path = tmp.name
         with zipfile.ZipFile(zip_path, 'w', zipfile.ZIP_DEFLATED) as zf:
             zf.writestr('metadata.json', json.dumps(metadata, indent=2))
-            for r in approved:
-                repo_slug = r['github_repo'].replace('https://github.com/', '').replace('/', '_')
+            for index, r in enumerate(approved, start=1):
+                repo_slug = _share_target_slug(r, index)
                 for t in r['trajectories']:
                     zf.write(t, f"{repo_slug}/{Path(t).name}")
         print(f"Uploading {len(all_trajs)} trajectories ...")

--- a/tests/test_trajectory.py
+++ b/tests/test_trajectory.py
@@ -714,6 +714,97 @@ class TestParseGithubOwnerRepo:
 
 
 # ---------------------------------------------------------------------------
+# share-trajectories
+# ---------------------------------------------------------------------------
+
+class TestShareTrajectories:
+    def _write_share_trajectory(self, root, repo, session_id):
+        traj_dir = root / "claude" / "projects" / "proj"
+        traj_dir.mkdir(parents=True)
+        traj_path = traj_dir / f"{session_id}.jsonl"
+        events = [
+            _make_tool_use_event(
+                "e1",
+                "t1",
+                "Write",
+                {"file_path": str(repo / "src" / "main.py"), "content": "print('hi')\n"},
+                session_id=session_id,
+                cwd=str(repo),
+            ),
+        ]
+        _write_jsonl(str(traj_path), events)
+        return traj_path
+
+    def test_collect_shareable_trajectories_includes_private_repo(self, tmp_path, monkeypatch):
+        from reproducible_trajectories.trajectory import collect_shareable_trajectories
+
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        self._write_share_trajectory(tmp_path, repo, "share-session-1")
+
+        monkeypatch.setattr(
+            "reproducible_trajectories.trajectory._find_git_root",
+            lambda _path: str(repo),
+        )
+        monkeypatch.setattr(
+            "reproducible_trajectories.trajectory._get_github_remote_urls",
+            lambda _repo_path: set(),
+        )
+
+        results = collect_shareable_trajectories(
+            claude_dir=str(tmp_path / "claude"),
+            codex_dir=str(tmp_path / "codex"),
+        )
+
+        assert len(results) == 1
+        assert results[0]["local_folder"] == str(repo)
+        assert results[0]["github_repo"] is None
+        assert len(results[0]["trajectories"]) == 1
+
+    def test_open_source_trajectories_excludes_private_repo(self, tmp_path, monkeypatch):
+        from reproducible_trajectories.trajectory import open_source_trajectories
+
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        self._write_share_trajectory(tmp_path, repo, "share-session-2")
+
+        monkeypatch.setattr(
+            "reproducible_trajectories.trajectory._find_git_root",
+            lambda _path: str(repo),
+        )
+        monkeypatch.setattr(
+            "reproducible_trajectories.trajectory._get_github_remote_urls",
+            lambda _repo_path: set(),
+        )
+
+        results = open_source_trajectories(
+            claude_dir=str(tmp_path / "claude"),
+            codex_dir=str(tmp_path / "codex"),
+        )
+
+        assert results == []
+
+    def test_prompt_share_scope_reassures_about_filtering(self, monkeypatch, capsys):
+        from reproducible_trajectories.trajectory import _prompt_share_scope
+
+        prompts = []
+
+        def fake_input(prompt):
+            prompts.append(prompt)
+            return "2"
+
+        monkeypatch.setattr("builtins.input", fake_input)
+
+        result = _prompt_share_scope()
+
+        captured = capsys.readouterr()
+        assert result == "open-source"
+        assert "1) share all trajectories" in captured.out
+        assert "2) only share the ones from open-source repositories" in captured.out
+        assert prompts == ["All collected data will be properly filtered and anonymized. [1/2/N] "]
+
+
+# ---------------------------------------------------------------------------
 # verify_trajectories  (integration-style with a temp git repo)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- rename the interactive sharing command to `share-trajectories` while keeping `open-source-trajectories` as a compatibility alias
- add a first prompt that lets users choose between sharing all trajectories or only open-source ones, with filtering/anonymization reassurance
- support sharing trajectories from non-public repos and cover the new behavior with tests

## Testing
- python -m pytest tests/test_trajectory.py tests/test_pi_trajectory.py -q